### PR TITLE
Fix static-dynamic counts in auditor dashboards

### DIFF
--- a/src/main/java/acme/features/auditor/auditorDashboard/AuditorAuditorDashboardRepository.java
+++ b/src/main/java/acme/features/auditor/auditorDashboard/AuditorAuditorDashboardRepository.java
@@ -23,10 +23,10 @@ import acme.client.repositories.AbstractRepository;
 @Repository
 public interface AuditorAuditorDashboardRepository extends AbstractRepository {
 
-	@Query("select count(ca) from CodeAudit ca where ca.type = 'STATIC' and ca.auditor.id = :auditorId")
+	@Query("select count(ca) from CodeAudit ca where ca.type = acme.entities.codeAudit.Type.STATIC and ca.auditor.id = :auditorId")
 	Integer totalNumberOfStaticCodeAuditsByAuditorId(int auditorId);
 
-	@Query("select count(ca) from CodeAudit ca where ca.type = 'DYNAMIC' and ca.auditor.id = :auditorId")
+	@Query("select count(ca) from CodeAudit ca where ca.type = acme.entities.codeAudit.Type.DYNAMIC and ca.auditor.id = :auditorId")
 	Integer totalNumberOfDynamicCodeAuditsByAuditorId(int auditorId);
 
 	@Query("select avg(select count(ar) from AuditRecord ar where ar.codeAudit.id = ca.id) " //
@@ -73,7 +73,10 @@ public interface AuditorAuditorDashboardRepository extends AbstractRepository {
 		+ "WHERE ca.auditor_id = :auditorId", nativeQuery = true)
 	Double maxAuditRecordPeriodLengthByAuditorId(@Param("auditorId") int auditorId);
 
-	@Query(value = "SELECT STDDEV(TIMESTAMPDIFF(second, ar.period_start, ar.period_end)) " //
+	@Query(value = "SELECT CASE " //
+		+ "WHEN COUNT(ar.id) < 2 THEN NULL " //
+		+ "ELSE STDDEV(TIMESTAMPDIFF(second, ar.period_start, ar.period_end)) " //
+		+ "END " //
 		+ "FROM Audit_Record ar JOIN Code_Audit ca ON ar.code_audit_id = ca.id " //
 		+ "WHERE ca.auditor_id = :auditorId", nativeQuery = true)
 	Double stdAuditRecordPeriodLengthByAuditorId(@Param("auditorId") int auditorId);

--- a/src/main/java/acme/features/auditor/auditorDashboard/AuditorAuditorDashboardRepository.java
+++ b/src/main/java/acme/features/auditor/auditorDashboard/AuditorAuditorDashboardRepository.java
@@ -35,11 +35,11 @@ public interface AuditorAuditorDashboardRepository extends AbstractRepository {
 
 	@Query("select min(select count(ar) from AuditRecord ar where ar.codeAudit.id = ca.id) " //
 		+ "from CodeAudit ca where ca.auditor.id = :auditorId")
-	Double minAuditRecordsPerCodeAuditByAuditorId(int auditorId);
+	Integer minAuditRecordsPerCodeAuditByAuditorId(int auditorId);
 
 	@Query("select max(select count(ar) from AuditRecord ar where ar.codeAudit.id = ca.id) " //
 		+ "from CodeAudit ca where ca.auditor.id = :auditorId")
-	Double maxAuditRecordsPerCodeAuditByAuditorId(int auditorId);
+	Integer maxAuditRecordsPerCodeAuditByAuditorId(int auditorId);
 
 	default Double stdAuditRecordsPerCodeAuditByAuditorId(final int auditorId) {
 		Collection<Integer> counts = this.auditRecordsPerCodeAuditByAuditorId(auditorId);

--- a/src/main/java/acme/features/auditor/auditorDashboard/AuditorAuditorDashboardShowService.java
+++ b/src/main/java/acme/features/auditor/auditorDashboard/AuditorAuditorDashboardShowService.java
@@ -46,8 +46,8 @@ public class AuditorAuditorDashboardShowService extends AbstractService<Auditor,
 		Integer totalNumberOfDynamicCodeAudits;
 
 		Double avgAuditRecordsPerCodeAudit;
-		Double minAuditRecordsPerCodeAudit;
-		Double maxAuditRecordsPerCodeAudit;
+		Integer minAuditRecordsPerCodeAudit;
+		Integer maxAuditRecordsPerCodeAudit;
 		Double stdAuditRecordsPerCodeAudit;
 
 		Double avgAuditRecordPeriodLength;

--- a/src/main/java/acme/forms/AuditorDashboard.java
+++ b/src/main/java/acme/forms/AuditorDashboard.java
@@ -30,8 +30,8 @@ public class AuditorDashboard extends AbstractForm {
 	private Integer				totalNumberOfDynamicCodeAudits;
 
 	private Double				avgAuditRecordsPerCodeAudit;
-	private Double				minAuditRecordsPerCodeAudit;
-	private Double				maxAuditRecordsPerCodeAudit;
+	private Integer				minAuditRecordsPerCodeAudit;
+	private Integer				maxAuditRecordsPerCodeAudit;
 	private Double				stdAuditRecordsPerCodeAudit;
 
 	private Double				avgAuditRecordPeriodLength;

--- a/src/main/webapp/WEB-INF/views/auditor/auditor-dashboard/messages-en.i18n
+++ b/src/main/webapp/WEB-INF/views/auditor/auditor-dashboard/messages-en.i18n
@@ -18,7 +18,7 @@ auditor.auditor-dashboard.form-label.min-audit-records-per-code-audit = Minimum 
 auditor.auditor-dashboard.form-label.max-audit-records-per-code-audit = Maximum number of audit records per code audit
 auditor.auditor-dashboard.form-label.std-audit-records-per-code-audit = Standard deviation of audit records per code audit
 
-auditor.auditor-dashboard.form-label.avg-audit-record-period-length = Average audit record period length per code audit (in seconds)
-auditor.auditor-dashboard.form-label.min-audit-record-period-length = Minimum audit record period length per code audit (in seconds)
-auditor.auditor-dashboard.form-label.max-audit-record-period-length = Maximum audit record period length per code audit (in seconds)
-auditor.auditor-dashboard.form-label.std-audit-record-period-length = Standard deviation audit record period length per code audit (in seconds)
+auditor.auditor-dashboard.form-label.avg-audit-record-period-length = Average audit record period length (in seconds)
+auditor.auditor-dashboard.form-label.min-audit-record-period-length = Minimum audit record period length (in seconds)
+auditor.auditor-dashboard.form-label.max-audit-record-period-length = Maximum audit record period length (in seconds)
+auditor.auditor-dashboard.form-label.std-audit-record-period-length = Standard deviation audit record period length (in seconds)

--- a/src/main/webapp/WEB-INF/views/auditor/auditor-dashboard/messages-es.i18n
+++ b/src/main/webapp/WEB-INF/views/auditor/auditor-dashboard/messages-es.i18n
@@ -18,7 +18,7 @@ auditor.auditor-dashboard.form-label.min-audit-records-per-code-audit = Mínimo 
 auditor.auditor-dashboard.form-label.max-audit-records-per-code-audit = Máximo número de registros de audiotría por auditoría de código
 auditor.auditor-dashboard.form-label.std-audit-records-per-code-audit = Desviación típica de registros de audiotría por auditoría de código
 
-auditor.auditor-dashboard.form-label.avg-audit-record-period-length = Longitud promedio de registro de auditoría por auditoría de código (en segundos)
-auditor.auditor-dashboard.form-label.min-audit-record-period-length = Longitud mínima de registro de auditoría por auditoría de código (en segundos)
-auditor.auditor-dashboard.form-label.max-audit-record-period-length = Longitud máxima de registro de auditoría por auditoría de código (en segundos)
-auditor.auditor-dashboard.form-label.std-audit-record-period-length = Desviación típica de longitud de registro de auditoría por auditoría de código (en segundos)
+auditor.auditor-dashboard.form-label.avg-audit-record-period-length = Longitud promedio de registro de auditoría (en segundos)
+auditor.auditor-dashboard.form-label.min-audit-record-period-length = Longitud mínima de registro de auditoría (en segundos)
+auditor.auditor-dashboard.form-label.max-audit-record-period-length = Longitud máxima de registro de auditoría (en segundos)
+auditor.auditor-dashboard.form-label.std-audit-record-period-length = Desviación típica de longitud de registro de auditoría (en segundos)


### PR DESCRIPTION
- Fixed the queries so the dashboards show the actual numbers.
- Added a restraint in the standard deviation of audit record duration so it only counts if there are at least 2 audit records.